### PR TITLE
Implement serialisation for all required objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(testmatch_backend)
 include(CTest)
+include(GenerateExportHeader)
 # Boost variables, dependent upon os
 #set(Boost_DEBUG 1)
 #set(Boost_COMPILER "-vc142")
@@ -45,7 +46,7 @@ include_directories(${Boost_INCLUDE_DIR})
 ###############################################################################
 
 # add the data to the target, so it becomes visible in some IDE
-add_library(backend ${sources})
+add_library(backend SHARED ${sources})
 
 target_include_directories(backend PUBLIC include)
 
@@ -57,6 +58,10 @@ target_link_libraries(backend PUBLIC
 if (WIN32)
   #set_target_properties(backend PROPERTIES LINK_FLAGS /FORCE:MULTIPLE)
 endif()
+
+# Generate macros for exporting functions 
+generate_export_header(backend)
+target_include_directories(backend PUBLIC ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR})
 
 ###############################################################################
 ## testing ####################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,8 @@ target_link_libraries(TestMatch PUBLIC
 
 
 # Generate macros for exporting functions 
-generate_export_header(backend)
-target_include_directories(backend PUBLIC ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR})
+generate_export_header(TestMatch)
+target_include_directories(TestMatch PUBLIC ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR})
 
 
 # OPTIONAL: Build tests:

--- a/include/Cards.h
+++ b/include/Cards.h
@@ -1,3 +1,4 @@
+// -*- lsst-c++ -*-
 /**
  * @file Cards.h
  * @author L. Blake

--- a/include/Cards.h
+++ b/include/Cards.h
@@ -1,6 +1,11 @@
-// -*- lsst-c++ -*-
-/* Cards.h
+/**
+ * @file Cards.h
+ * @author L. Blake
+ * @brief
+ * @version 0.1
+ * @date 2021-03-28
  *
+ * @copyright Copyright (c) 2021
  *
  */
 
@@ -9,6 +14,8 @@
 
 #include <random>
 #include <string>
+
+#include <boost/serialization/base_object.hpp>
 
 #include "Player.h"
 
@@ -35,6 +42,18 @@ struct BatStats {
   int balls;
   int fours;
   int sixes;
+
+  // Serialisation methods
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& bat_avg;
+    ar& strike_rate;
+    ar& bat_hand;
+    ar& runs;
+    ar& balls;
+    ar& fours;
+    ar& sixes;
+  };
 };
 
 /**
@@ -66,6 +85,26 @@ struct BowlStats {
   int spell_maidens;
   int spell_runs;
   int spell_wickets;
+
+  // Serialisation methods
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& bowl_avg;
+    ar& strike_rate;
+    ar& bowl_type;
+    ar& balls;
+    ar& overs;
+    ar& over_balls;
+    ar& maidens;
+    ar& runs;
+    ar& wickets;
+    ar& legal_balls;
+    ar& spell_balls;
+    ar& spell_overs;
+    ar& spell_maidens;
+    ar& spell_runs;
+    ar& spell_wickets;
+  };
 };
 
 /**
@@ -114,6 +153,15 @@ class Dismissal {
    * @return
    */
   Player* get_fielder();
+
+  // Serialisation methods
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& mode;
+    ar& mode;
+    ar& bowler;
+    ar& fielder;
+  };
 };
 
 /**
@@ -173,13 +221,18 @@ class PlayerCard {
   virtual std::string print_card(void) = 0;
 
   // Default destructor
+
+  // Serialisation methods
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& player;
+  };
 };
 
 /**
  * @brief
  */
 class BatterCard : public PlayerCard {
-  // TODO: implement MATCHTIME
 
  private:
   BatStats stats;
@@ -211,6 +264,17 @@ class BatterCard : public PlayerCard {
   // BatterCard(const BatterCard& bc);
 
   ~BatterCard();
+
+  // Serialisation methods
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<PlayerCard>(*this);
+    ar& stats;
+    ar& active;
+    ar& out;
+    ar& dism;
+    ar& mins;
+  };
 };
 
 /**
@@ -231,7 +295,7 @@ class BowlerCard : public PlayerCard {
 
   // Tracks number of runs in a current over to determine whether that over was
   // a maiden
-  bool is_maiden;
+  bool is_maiden = true;
 
   void add_ball();
 
@@ -254,6 +318,16 @@ class BowlerCard : public PlayerCard {
 
   std::string print_card(void);
   std::string print_spell(void);
+
+  // Serialisation methods
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<PlayerCard>(*this);
+    ar& stats;
+    ar& active;
+    ar& competency;
+    ar& add_ball;
+  };
 };
 
 template <typename T>
@@ -271,10 +345,16 @@ BowlerCard** create_bowling_cards(Team* team);
 struct PitchFactors {
   double seam;
   double spin;
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& seam;
+    ar& spin;
+  };
 };
 
 /**
- * @brief
+ * @brief Describes a venue and pitch conditions.
  */
 struct Venue {
   std::string name;
@@ -282,6 +362,14 @@ struct Venue {
   std::string country;
 
   PitchFactors* pitch_factors;
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& name;
+    ar& city;
+    ar& country;
+    ar& pitch_factors;
+  };
 };
 
 /**
@@ -307,6 +395,16 @@ struct Ball {
   Ball* next = nullptr;
 
   Ball* get_next() { return next; };
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& bowler;
+    ar& batter;
+    ar& outcome;
+    ar& legal;
+    ar& commentary;
+    ar& next;
+  };
 };
 
 /**
@@ -354,6 +452,16 @@ class Over {
   void add_ball(Ball* ball);
 
   ~Over();
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& over_num;
+    ar& first;
+    ar& last;
+    ar& num_balls;
+    ar& num_legal_delivs;
+    ar& next;
+  };
 };
 
 class Extras {
@@ -369,6 +477,14 @@ class Extras {
   bool update_score(std::string outcome);
   std::string print();
   int total();
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& byes;
+    ar& legbyes;
+    ar& noballs;
+    ar& wides;
+  }
 };
 
 struct FOW {
@@ -382,6 +498,14 @@ struct FOW {
   std::string print();
 
   // TODO: implement value checking for 0 <= balls < 6
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& wkts;
+    ar& runs;
+    ar& overs;
+    ar& balls;
+  }
 };
 
 /**
@@ -425,6 +549,18 @@ class Partnership {
    */
   void add_runs(unsigned int n_runs, bool scorer, bool add_ball);
   void end();
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& bat1;
+    ar& bat2;
+    ar& runs;
+    ar& bat1_runs;
+    ar& bat1_balls;
+    ar& bat2_runs;
+    ar& bat2_balls;
+    ar& not_out;
+  };
 };
 
 //~~~~~~~~~~~~~~ Match End Objects ~~~~~~~~~~~~~~//
@@ -447,6 +583,12 @@ class EndMatch {
   virtual std::string print() = 0;
 
   // Default destructor
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& winner;
+    ar& margin;
+  };
 };
 
 /**
@@ -457,6 +599,11 @@ class EndInningsWin : public EndMatch {
   EndInningsWin(Team* c_winner, int c_runs);
 
   std::string print();
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<EndMatch>(*this);
+  };
 };
 
 /**
@@ -467,6 +614,11 @@ class EndBowlWin : public EndMatch {
   EndBowlWin(Team* c_winner, int c_runs);
 
   std::string print();
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<EndMatch>(*this);
+  };
 };
 
 /**
@@ -477,6 +629,11 @@ class EndChaseWin : public EndMatch {
   EndChaseWin(Team* c_winner, int c_wkts);
 
   std::string print();
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<EndMatch>(*this);
+  };
 };
 
 /**
@@ -487,6 +644,11 @@ class EndDraw : public EndMatch {
   EndDraw();
 
   virtual std::string print();
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<EndMatch>(*this);
+  };
 };
 
 /**
@@ -497,6 +659,11 @@ class EndTie : public EndDraw {
   EndTie();
 
   std::string print();
+
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& boost::serialization::base_object<EndDraw>(*this);
+  };
 };
 
 ///// CURRENTLY UNDEFINED - FOR TRACKING MILESTONES

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -302,6 +302,39 @@ class Innings {
   // Destructor
   ~Innings();
 
+  // Serialisation
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& team_bat;
+    ar& team_bowl;
+
+    ar& inns_no;
+    ar& is_quiet;
+
+    ar& overs;
+    ar& balls;
+    ar& legal_delivs;
+    ar& team_score;
+    ar& lead;
+    ar& wkts;
+
+    ar& is_open;
+
+    // ar& time;
+    ar& pitch;
+
+    ar& first_over;
+    ar& last_over;
+
+    ar& batters;
+    ar& bowlers;
+
+    ar& bat_parts;
+
+    ar& extras;
+    ar& fow;
+  }
+
   // Allow manager objects to access private members
   friend class BattingManager;
   friend class BowlingManager;
@@ -387,6 +420,28 @@ class Match {
   std::string print_all();
 
   ~Match();
+
+  // Serialisation
+  template <class Archive>
+  void serialize(Archive& ar, const unsigned int version) {
+    ar& team1;
+    ar& team2;
+
+    ar& venue;
+
+    ar& ready;
+    ar& toss_win;
+    ar& toss_elect;
+
+    ar& match_state;
+
+    ar& inns_i;
+    ar& inns;
+    ar& lead;
+    ar& match_balls;
+
+    ar& ending;
+  }
 };
 
 #endif // SIMULATION_h

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Demonstrative test (for run-time errors)
-add_executable(demo_test ${sources_demo})
+# add_executable(demo_test ${sources_demo})
 
-target_include_directories(demo_test PUBLIC includes)
-target_include_directories(demo_test PUBLIC ${Boost_INCLUDE_DIR})
-target_link_libraries(demo_test PUBLIC
-  ${Boost_LIBRARIES}
-  backend
-)
+# target_include_directories(demo_test PUBLIC includes)
+# target_include_directories(demo_test PUBLIC ${Boost_INCLUDE_DIR})
+# target_link_libraries(demo_test PUBLIC
+#   ${Boost_LIBRARIES}
+#   backend
+# )
 
 #set_target_properties(demo_test PROPERTIES LINK_FLAGS /SUBSYSTEM:CONSOLE)
 #add_test(NAME demo COMMAND demo_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Demonstrative test (for run-time errors)
 add_executable(demo_test ${sources_demo})
 
-target_include_directories(demo_test PUBLIC include)
+target_include_directories(demo_test PUBLIC includes)
 include_directories(demo_test ${Boost_INCLUDE_DIR})
 target_link_libraries(demo_test PUBLIC
   ${Boost_LIBRARIES}
@@ -16,7 +16,7 @@ add_executable(unit_tests ${sources_unittests})
 
 target_compile_definitions(unit_tests PUBLIC UNIT_TESTS)
 
-target_include_directories(unit_tests PUBLIC include)
+target_include_directories(unit_tests PUBLIC includes)
 include_directories(unit_tests ${Boost_INCLUDE_DIR})
 target_link_libraries(unit_tests PUBLIC
   ${Boost_LIBRARIES}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ target_include_directories(demo_test PUBLIC includes)
 target_include_directories(demo_test PUBLIC ${Boost_INCLUDE_DIR})
 target_link_libraries(demo_test PUBLIC
   ${Boost_LIBRARIES}
-  backend
+  TestMatch
 )
 
 #set_target_properties(demo_test PROPERTIES LINK_FLAGS /SUBSYSTEM:CONSOLE)
@@ -20,7 +20,7 @@ target_include_directories(unit_tests PUBLIC includes)
 target_include_directories(unit_tests PUBLIC ${Boost_INCLUDE_DIR})
 target_link_libraries(unit_tests PUBLIC
   ${Boost_LIBRARIES}
-  backend
+  TestMatch
 )
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,12 @@
 # Demonstrative test (for run-time errors)
-# add_executable(demo_test ${sources_demo})
+add_executable(demo_test ${sources_demo})
 
-# target_include_directories(demo_test PUBLIC includes)
-# target_include_directories(demo_test PUBLIC ${Boost_INCLUDE_DIR})
-# target_link_libraries(demo_test PUBLIC
-#   ${Boost_LIBRARIES}
-#   backend
-# )
+target_include_directories(demo_test PUBLIC includes)
+target_include_directories(demo_test PUBLIC ${Boost_INCLUDE_DIR})
+target_link_libraries(demo_test PUBLIC
+  ${Boost_LIBRARIES}
+  backend
+)
 
 #set_target_properties(demo_test PROPERTIES LINK_FLAGS /SUBSYSTEM:CONSOLE)
 #add_test(NAME demo COMMAND demo_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_executable(demo_test ${sources_demo})
 
 target_include_directories(demo_test PUBLIC includes)
-include_directories(demo_test ${Boost_INCLUDE_DIR})
+target_include_directories(demo_test PUBLIC ${Boost_INCLUDE_DIR})
 target_link_libraries(demo_test PUBLIC
   ${Boost_LIBRARIES}
   backend
@@ -17,7 +17,7 @@ add_executable(unit_tests ${sources_unittests})
 target_compile_definitions(unit_tests PUBLIC UNIT_TESTS)
 
 target_include_directories(unit_tests PUBLIC includes)
-include_directories(unit_tests ${Boost_INCLUDE_DIR})
+target_include_directories(unit_tests PUBLIC ${Boost_INCLUDE_DIR})
 target_link_libraries(unit_tests PUBLIC
   ${Boost_LIBRARIES}
   backend

--- a/test/demonstrative_test.cpp
+++ b/test/demonstrative_test.cpp
@@ -39,7 +39,7 @@ int main() {
   Player a5("Travis", "Head", "TM",
             {28, 41.96, 50.41, 126, 68.32, 63.7, 3.61, true, 4});
   Player a6("Cameron", "Green", "C",
-            {7, 40.71, 40.68, 264, 30.30, 50.7, 2.98, false, 2});
+            {7, 40.71, 40.68, 264, 35.30, 60.7, 2.98, false, 2});
   Player a7("Tim", "Paine", "TD",
             {50, 31.66, 44.24, 0, 1000, 1000, 4.00, false, 0});
   Player a8("Pat", "Cummins", "PJ",


### PR DESCRIPTION
Using Boost serialisation library, all required objects can be serialised, saved via the `save_data` template function, and the loaded via `load_data`.